### PR TITLE
Add hint support to getDailyDrug backend

### DIFF
--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -63,7 +63,7 @@ resource "aws_iam_role_policy" "rotate_daily_drug" {
       {
         Effect   = "Allow"
         Action   = "s3:GetObject"
-        Resource = "${aws_s3_bucket.pharmdle.arn}/drug_names"
+        Resource = "${aws_s3_bucket.pharmdle.arn}/drug_data"
       },
       {
         Effect = "Allow"

--- a/terraform/lambda.tf
+++ b/terraform/lambda.tf
@@ -79,7 +79,7 @@ resource "aws_lambda_function" "rotate_daily_drug" {
   environment {
     variables = {
       BUCKET_NAME    = aws_s3_bucket.pharmdle.id
-      DRUG_NAMES_KEY = "drug_names"
+      DRUG_DATA_KEY  = "drug_data"
       DAILY_DRUG_KEY = "daily_drug"
     }
   }

--- a/terraform/lambdas/getDailyDrug/index.mjs
+++ b/terraform/lambdas/getDailyDrug/index.mjs
@@ -3,10 +3,9 @@ import { S3Client, GetObjectCommand } from "@aws-sdk/client-s3";
 const client = new S3Client({});
 
 export const handler = async (event) => {
-    //console.log('Received event:', JSON.stringify(event, null, 2));
-
     const bucket = process.env.BUCKET_NAME;
     const key = process.env.DAILY_DRUG_KEY;
+    const wantHints = event.queryStringParameters?.hints === 'true';
 
     try {
         const response = await client.send(
@@ -14,14 +13,23 @@ export const handler = async (event) => {
                 Bucket: bucket,
                 Key: key,
             }),
-            );    
-            const str = await response.Body.transformToString();
-            return {
-                statusCode: 200, 
-                body: str
-            }
+        );
+        const str = await response.Body.transformToString();
+        const drugObj = JSON.parse(str);
 
-} catch (err) {
+        if (wantHints) {
+            return {
+                statusCode: 200,
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify(drugObj),
+            };
+        }
+
+        return {
+            statusCode: 200,
+            body: drugObj.name,
+        };
+    } catch (err) {
         console.log(err);
         const message = `Error getting object ${key} from bucket ${bucket}. Make sure they exist and your bucket is in the same region as this function.`;
         console.log(message);

--- a/terraform/lambdas/rotateDailyDrug/index.mjs
+++ b/terraform/lambdas/rotateDailyDrug/index.mjs
@@ -7,26 +7,27 @@ export const handler = async (event) => {
     const response = await client.send(
       new GetObjectCommand({
         Bucket: process.env.BUCKET_NAME,
-        Key: process.env.DRUG_NAMES_KEY,
+        Key: process.env.DRUG_DATA_KEY,
       })
     );
 
     const str = await response.Body.transformToString();
-    const drugs = str.split('\n');
-    const indx = Math.floor(Math.random() * drugs.length - 1);
+    const drugs = JSON.parse(str);
+    const indx = Math.floor(Math.random() * drugs.length);
     const newDrug = drugs[indx];
-    console.log(`new drug: ${newDrug}, writing to S3`);
+    console.log(`new drug: ${newDrug.name}, writing to S3`);
 
     // write new value to S3
     const writeResponse = await client.send(
       new PutObjectCommand({
         Bucket: process.env.BUCKET_NAME,
         Key: process.env.DAILY_DRUG_KEY,
-        Body: newDrug
+        Body: JSON.stringify(newDrug),
+        ContentType: 'application/json',
       })
     );
 
-    console.log(writeResponse); 
+    console.log(writeResponse);
     if (writeResponse.$metadata.httpStatusCode != 200) {
       throw new Error('Error writing to S3');
     }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -31,17 +31,19 @@ resource "aws_s3_bucket_public_access_block" "pharmdle" {
 
 # --- S3 objects ---
 
-resource "aws_s3_object" "drug_names" {
-  bucket = aws_s3_bucket.pharmdle.id
-  key    = "drug_names"
-  source = var.drug_names_file
-  etag   = filemd5(var.drug_names_file)
+resource "aws_s3_object" "drug_data" {
+  bucket       = aws_s3_bucket.pharmdle.id
+  key          = "drug_data"
+  source       = var.drug_data_file
+  etag         = filemd5(var.drug_data_file)
+  content_type = "application/json"
 }
 
 resource "aws_s3_object" "daily_drug" {
-  bucket  = aws_s3_bucket.pharmdle.id
-  key     = "daily_drug"
-  content = var.daily_drug_default
+  bucket       = aws_s3_bucket.pharmdle.id
+  key          = "daily_drug"
+  content      = jsonencode({ name = var.daily_drug_default })
+  content_type = "application/json"
 
   lifecycle {
     ignore_changes = [content, etag]

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -16,10 +16,10 @@ variable "aws_account_id" {
   default     = "842817210846"
 }
 
-variable "drug_names_file" {
-  description = "Local path to the drug_names file"
+variable "drug_data_file" {
+  description = "Local path to the drug_data.json file"
   type        = string
-  default     = "../utils/drug_names"
+  default     = "../utils/drug_data.json"
 }
 
 variable "daily_drug_default" {


### PR DESCRIPTION
## Summary
- Replace `drug_names` (plain text list) with `drug_data` (JSON array of drug objects enriched with hint attributes from FDA data)
- `rotateDailyDrug` Lambda now writes the full drug object (name + hints) as JSON to `daily_drug` in S3
- `getDailyDrug` Lambda returns plain text drug name by default (non-breaking), or full JSON object when called with `?hints=true`
- Hint attributes: `product_type`, `route`, `dosage_form`, `marketing_status`, `pharm_class_epc`, `pharm_class_moa`

## Test plan
- [x] `curl <function_url>` returns plain text drug name (verified: `etrasimod`)
- [x] `curl "<function_url>?hints=true"` returns JSON with drug name and all hint fields
- [x] Existing frontend continues to work unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)