### PR TITLE
Add hints drawer UI

### DIFF
--- a/src/Pharmdle.tsx
+++ b/src/Pharmdle.tsx
@@ -1,10 +1,11 @@
-import React, { use, useEffect, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import PharmdleRow from './PharmdleRow';
-import { Box, Button, Modal, Stack, Typography } from '@mui/material';
+import { Stack } from '@mui/material';
 import usePharmdle from './hooks/usePharmdle';
 import Keypad from './Keypad';
 import LostGameModal from './components/LostGameModal';
 import WonGameModal from './components/WonGameModal';
+import HintsDrawer from './components/HintsDrawer';
 
 export interface PharmdleGridProps {
   numRows: number;
@@ -22,15 +23,19 @@ const Pharmdle = ({ numRows }: PharmdleGridProps) => {
   } = usePharmdle(8);
 
   const [modalCleared, setModalCleared] = useState(false);
+  const [hints, setHints] = useState<Record<string, string[]> | null>(null);
+  const [drawerOpen, setDrawerOpen] = useState(false);
 
   useEffect(() => {
     const fetchDailyDrug = async () => {
       const response = await fetch(
-        'https://5bpsqzakript5dai5nolgdvv6e0tkmbr.lambda-url.us-east-1.on.aws/'
+        'https://5bpsqzakript5dai5nolgdvv6e0tkmbr.lambda-url.us-east-1.on.aws/?hints=true'
       );
-      const drug = await response.text();
-      console.log('fetched drug:', drug);
-      setSolution(drug.padEnd(14, '*'));
+      const data = await response.json();
+      console.log('fetched drug:', data.name);
+      setSolution(data.name.padEnd(14, '*'));
+      const { name, ...hintData } = data;
+      setHints(hintData);
     };
 
     fetchDailyDrug();
@@ -71,6 +76,11 @@ const Pharmdle = ({ numRows }: PharmdleGridProps) => {
         ))}
       </Stack>
       <Keypad usedKeys={usedKeys} onKeyClick={(key) => handleKeyup({ key })} />
+      <HintsDrawer
+        hints={hints}
+        open={drawerOpen}
+        onToggle={() => setDrawerOpen(!drawerOpen)}
+      />
       <LostGameModal
         open={shouldShowLostGameModal() && !modalCleared}
         solution={solution}

--- a/src/components/HintsDrawer.tsx
+++ b/src/components/HintsDrawer.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+
+interface HintsDrawerProps {
+  hints: Record<string, string[]> | null;
+  open: boolean;
+  onToggle: () => void;
+}
+
+const HINT_LABELS: Record<string, string> = {
+  product_type: 'Product Type',
+  route: 'Route',
+  dosage_form: 'Dosage Form',
+  marketing_status: 'Marketing Status',
+  pharm_class_epc: 'Pharm Class (EPC)',
+  pharm_class_moa: 'Pharm Class (MOA)',
+};
+
+const HINT_ORDER = [
+  'route',
+  'dosage_form',
+  'product_type',
+  'marketing_status',
+  'pharm_class_epc',
+  'pharm_class_moa',
+];
+
+const HintsDrawer = ({ hints, open, onToggle }: HintsDrawerProps) => {
+  if (!hints) return null;
+
+  return (
+    <>
+      <div className="hints-btn-container">
+        <button className="hints-btn" onClick={onToggle}>
+          Hints
+        </button>
+      </div>
+
+      {open && <div className="hints-drawer-overlay" onClick={onToggle} />}
+
+      <div className={`hints-drawer ${open ? 'open' : ''}`}>
+        <div className="hints-drawer-header">
+          <span>Hints</span>
+          <button className="hints-drawer-close" onClick={onToggle}>
+            &times;
+          </button>
+        </div>
+        <div className="hints-drawer-body">
+          {HINT_ORDER.map((key) => (
+            <div className="hint-row" key={key}>
+              <span className="hint-label">{HINT_LABELS[key]}</span>
+              <span className="hint-value">
+                {hints[key]?.length ? hints[key].join(', ') : '\u2014'}
+              </span>
+            </div>
+          ))}
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default HintsDrawer;

--- a/src/index.css
+++ b/src/index.css
@@ -147,6 +147,102 @@ body {
   letter-spacing: 1px;
 }
 
+/* hints button */
+.hints-btn-container {
+  text-align: center;
+  margin: 12px 0 20px;
+}
+.hints-btn {
+  background: #818384;
+  color: #fff;
+  border: none;
+  border-radius: 20px;
+  padding: 8px 24px;
+  font-size: 0.9em;
+  font-weight: bold;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  cursor: pointer;
+  user-select: none;
+}
+.hints-btn:active {
+  transform: scale(0.95);
+}
+
+/* hints drawer */
+.hints-drawer-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(18, 18, 19, 0.6);
+  z-index: 10;
+}
+.hints-drawer {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  max-height: 50vh;
+  background: #1a1a1b;
+  border-radius: 16px 16px 0 0;
+  box-shadow: 0 -4px 20px rgba(0, 0, 0, 0.5);
+  transform: translateY(100%);
+  transition: transform 0.3s ease;
+  z-index: 11;
+  overflow-y: auto;
+}
+.hints-drawer.open {
+  transform: translateY(0);
+}
+.hints-drawer-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 16px 20px 8px;
+  font-size: 1.1em;
+  font-weight: bold;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  border-bottom: 1px solid #3a3a3c;
+}
+.hints-drawer-close {
+  background: none;
+  border: none;
+  color: #818384;
+  font-size: 1.5em;
+  cursor: pointer;
+  padding: 0 4px;
+  line-height: 1;
+}
+.hints-drawer-body {
+  padding: 12px 20px 24px;
+}
+.hint-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  padding: 10px 0;
+  border-bottom: 1px solid #2a2a2b;
+}
+.hint-row:last-child {
+  border-bottom: none;
+}
+.hint-label {
+  color: #818384;
+  font-size: 0.8em;
+  font-weight: bold;
+  text-transform: uppercase;
+  flex-shrink: 0;
+  margin-right: 12px;
+}
+.hint-value {
+  color: #fff;
+  font-size: 0.85em;
+  text-align: right;
+}
+
 /* responsive tiles */
 @media (max-width: 600px) {
   .row > div {


### PR DESCRIPTION
## Summary
- Fetch daily drug with `?hints=true` to get hint metadata alongside the drug name
- New `HintsDrawer` component: "Hints" button below the keyboard opens a slide-up drawer
- Drawer shows all 6 hint categories: Route, Dosage Form, Product Type, Marketing Status, Pharm Class (EPC), Pharm Class (MOA)
- Hints are free to use (no penalty), all revealed at once
- Drawer dismisses via overlay tap or close button

## Test plan
- [x] App loads normally, "Hints" button visible below keyboard
- [x] Tapping "Hints" opens drawer with correct hint data for today's drug
- [x] Drawer dismisses when tapping overlay or close button
- [x] Game still functions normally (typing, guessing, win/loss modals)
- [x] Responsive: drawer and button scale on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)