### PR TITLE
Make trailing padding tiles green

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,22 @@ npm run build
 
 Outputs an optimised production build to the `build/` directory.
 
+## Deployment
+
+The frontend is continuously deployed via **AWS Amplify**. Pushing to the `main` branch automatically triggers a build and deploy.
+
+### Checking Deployment Status
+
+```bash
+# List recent deployments
+aws amplify list-jobs --app-id d1zf2mt5b84s5d --branch-name main --max-items 5
+
+# Get details for a specific job
+aws amplify get-job --app-id d1zf2mt5b84s5d --branch-name main --job-id <JOB_ID>
+```
+
+You can also check the [Amplify console](https://us-east-1.console.aws.amazon.com/amplify/apps/d1zf2mt5b84s5d) directly.
+
 ## Infrastructure (Terraform)
 
 Backend infrastructure is managed with Terraform in the `terraform/` directory.

--- a/src/PharmdleRow.tsx
+++ b/src/PharmdleRow.tsx
@@ -10,17 +10,13 @@ export interface PharmdleRowProps {
 
 const Row = ({ numCols, existingGuess, guessInProgress }: PharmdleRowProps) => {
   if (existingGuess) {
-    // this row is already locked
-    const emptyCount = numCols - existingGuess.formatted.length;
+    // this row is already locked — formatted is always 14 entries
     return (
       <div className="row past">
         {existingGuess.formatted.map((l, i) => (
-          <div key={i} className={l.color}>
+          <div key={i} className={l.color || undefined}>
             {l.key}
           </div>
-        ))}
-        {emptyCount > 0 && [...Array(emptyCount)].map((_, i) => (
-          <div key={`empty-${i}`}></div>
         ))}
       </div>
     );

--- a/src/hooks/usePharmdle.ts
+++ b/src/hooks/usePharmdle.ts
@@ -65,8 +65,8 @@ export interface Guess {
 }
 
 export interface GuessKey {
-  key: Letter;
-  color: Color;
+  key: Letter | '';
+  color: Color | '';
 }
 
 export interface KeyColorMap {
@@ -139,6 +139,14 @@ const usePharmdle = (numTurns: number, validDrugs: Set<string>) => {
       }
     });
 
+    // pad to 14 columns: positions beyond the solution are green (correctly blank)
+    for (let i = guess.length; i < 14; i++) {
+      formattedGuess.formatted.push({
+        key: '',
+        color: i >= solution.length ? 'green' : '',
+      });
+    }
+
     return formattedGuess;
   };
 
@@ -158,14 +166,16 @@ const usePharmdle = (numTurns: number, validDrugs: Set<string>) => {
 
     setUsedKeys((prevUsedKeys: KeyColorMap) => {
       formattedGuess.formatted.forEach((guessKeyColor) => {
-        const currentColor = prevUsedKeys[guessKeyColor.key];
+        if (!guessKeyColor.key) return; // skip blank padding cells
+        const key = guessKeyColor.key as Letter;
+        const currentColor = prevUsedKeys[key];
 
         if (guessKeyColor.color === 'green') {
-          prevUsedKeys[guessKeyColor.key] = 'green';
+          prevUsedKeys[key] = 'green';
           return;
         }
         if (guessKeyColor.color === 'yellow' && currentColor !== 'green') {
-          prevUsedKeys[guessKeyColor.key] = 'yellow';
+          prevUsedKeys[key] = 'yellow';
           return;
         }
       });


### PR DESCRIPTION
## Summary
- Extend `formatGuess` to always produce 14 entries — positions beyond the solution length are marked green, indicating the user correctly left those squares blank
- Update `GuessKey` type to allow empty key/color for padding positions
- Skip blank padding cells when updating keyboard color state
- Add AWS Amplify deployment status instructions to README

## Test plan
- [x] Guess a valid drug shorter than the solution — trailing cells beyond the solution length turn green after flip animation
- [x] Cells between guess length and solution length remain uncolored (empty)
- [x] Keyboard colors still update correctly (no errors from blank padding)
- [x] Win/lose detection still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)