### PR TITLE
Progressive hint reveal with usage tracking

### DIFF
--- a/src/Pharmdle.tsx
+++ b/src/Pharmdle.tsx
@@ -27,6 +27,7 @@ const Pharmdle = ({ numRows }: PharmdleGridProps) => {
   const [modalCleared, setModalCleared] = useState(false);
   const [hints, setHints] = useState<Record<string, string[]> | null>(null);
   const [drawerOpen, setDrawerOpen] = useState(false);
+  const [hintsUsed, setHintsUsed] = useState(0);
 
   useEffect(() => {
     const fetchDailyDrug = async () => {
@@ -52,6 +53,13 @@ const Pharmdle = ({ numRows }: PharmdleGridProps) => {
   // console.log(
   //   `turn: ${guesses.length}, currentGuess: ${currentGuess}, guesses: ${guesses}, usedKeys: ${usedKeys}, isCorrect: ${isCorrect}`
   // );
+
+  // Close hints drawer when game ends
+  useEffect(() => {
+    if (isCorrect || guesses.length === 8) {
+      setDrawerOpen(false);
+    }
+  }, [isCorrect, guesses.length]);
 
   if (!solution) {
     return <div>Loading...</div>;
@@ -83,17 +91,20 @@ const Pharmdle = ({ numRows }: PharmdleGridProps) => {
         hints={hints}
         open={drawerOpen}
         onToggle={() => setDrawerOpen(!drawerOpen)}
+        onReveal={(count) => setHintsUsed(count)}
       />
       <LostGameModal
         open={shouldShowLostGameModal() && !modalCleared}
         solution={solution}
         onClose={() => setModalCleared(true)}
+        hintsUsed={hintsUsed}
       />
       <WonGameModal
         open={shouldShowWonGameModal() && !modalCleared}
         solution={solution}
         onClose={() => setModalCleared(true)}
         numGuesses={guesses.length}
+        hintsUsed={hintsUsed}
       />
     </div>
   );

--- a/src/components/HintsDrawer.tsx
+++ b/src/components/HintsDrawer.tsx
@@ -1,9 +1,10 @@
-import React from 'react';
+import React, { useState, useMemo } from 'react';
 
 interface HintsDrawerProps {
   hints: Record<string, string[]> | null;
   open: boolean;
   onToggle: () => void;
+  onReveal: (count: number) => void;
 }
 
 const HINT_LABELS: Record<string, string> = {
@@ -24,14 +25,31 @@ const HINT_ORDER = [
   'pharm_class_moa',
 ];
 
-const HintsDrawer = ({ hints, open, onToggle }: HintsDrawerProps) => {
+const HintsDrawer = ({ hints, open, onToggle, onReveal }: HintsDrawerProps) => {
+  const [revealedHints, setRevealedHints] = useState<Set<string>>(new Set());
+
+  const availableHints = useMemo(() => {
+    if (!hints) return [];
+    return HINT_ORDER.filter((key) => hints[key]?.length > 0);
+  }, [hints]);
+
   if (!hints) return null;
+
+  const handleReveal = (key: string) => {
+    const updated = new Set(revealedHints);
+    updated.add(key);
+    setRevealedHints(updated);
+    onReveal(updated.size);
+  };
+
+  const revealedCount = revealedHints.size;
+  const totalCount = availableHints.length;
 
   return (
     <>
       <div className="hints-btn-container">
         <button className="hints-btn" onClick={onToggle}>
-          Hints
+          Hints{totalCount > 0 ? ` (${revealedCount}/${totalCount})` : ''}
         </button>
       </div>
 
@@ -45,12 +63,19 @@ const HintsDrawer = ({ hints, open, onToggle }: HintsDrawerProps) => {
           </button>
         </div>
         <div className="hints-drawer-body">
-          {HINT_ORDER.map((key) => (
+          {availableHints.map((key) => (
             <div className="hint-row" key={key}>
               <span className="hint-label">{HINT_LABELS[key]}</span>
-              <span className="hint-value">
-                {hints[key]?.length ? hints[key].join(', ') : '\u2014'}
-              </span>
+              {revealedHints.has(key) ? (
+                <span className="hint-value">{hints[key].join(', ')}</span>
+              ) : (
+                <button
+                  className="hint-reveal-btn"
+                  onClick={() => handleReveal(key)}
+                >
+                  Reveal
+                </button>
+              )}
             </div>
           ))}
         </div>

--- a/src/components/LostGameModal.tsx
+++ b/src/components/LostGameModal.tsx
@@ -5,10 +5,12 @@ const LostGameModal = ({
   solution,
   onClose,
   open,
+  hintsUsed,
 }: {
   solution: string;
   onClose: () => void;
   open: boolean;
+  hintsUsed: number;
 }) => {
   return (
     <div className="modal" hidden={!open}>
@@ -19,6 +21,9 @@ const LostGameModal = ({
           can't do any worse.
         </p>
         <p>The correct answer was: {solution.replaceAll('*', '')}</p>
+        <p>
+          Hints used: {hintsUsed}
+        </p>
         <Button variant="outlined" onClick={onClose}>
           Close
         </Button>

--- a/src/components/WonGameModal.tsx
+++ b/src/components/WonGameModal.tsx
@@ -6,11 +6,13 @@ const WonGameModal = ({
   onClose,
   open,
   numGuesses,
+  hintsUsed,
 }: {
   solution: string;
   onClose: () => void;
   open: boolean;
   numGuesses: number;
+  hintsUsed: number;
 }) => {
   return (
     <div className="modal" hidden={!open}>
@@ -18,7 +20,11 @@ const WonGameModal = ({
         <h2>You win!</h2>
         <p>
           You guessed the correct answer of {solution.replaceAll('*', '')} in{' '}
-          {numGuesses} {numGuesses === 1 ? 'try' : 'tries'}!
+          {numGuesses} {numGuesses === 1 ? 'try' : 'tries'}
+          {hintsUsed > 0
+            ? ` using ${hintsUsed} ${hintsUsed === 1 ? 'hint' : 'hints'}`
+            : ' using no hints'}
+          !
         </p>
         <Button variant="outlined" onClick={onClose}>
           Close

--- a/src/index.css
+++ b/src/index.css
@@ -242,6 +242,20 @@ body {
   font-size: 0.85em;
   text-align: right;
 }
+.hint-reveal-btn {
+  background: #3a3a3c;
+  color: #818384;
+  border: none;
+  border-radius: 4px;
+  padding: 4px 14px;
+  font-size: 0.8em;
+  font-weight: bold;
+  text-transform: uppercase;
+  cursor: pointer;
+}
+.hint-reveal-btn:active {
+  transform: scale(0.95);
+}
 
 /* responsive tiles */
 @media (max-width: 600px) {


### PR DESCRIPTION
## Summary
- Hint values are now hidden behind per-category "Reveal" buttons instead of being shown all at once
- Only categories with actual data are displayed (empty hints are filtered out)
- Hints button shows progress: "Hints (2/5)" indicating revealed vs available
- Win/lose modals display how many hints were used
- Hints drawer auto-closes when the game ends so it doesn't obscure the modal

## Test plan
- [x] Open hints drawer — categories show labels with "Reveal" buttons, no values visible
- [x] Click "Reveal" on a category — value appears, button text updates (e.g. "Hints (1/5)")
- [x] Empty hint categories are not shown
- [x] Win the game — modal shows "using N hints" or "using no hints"
- [x] Lose the game — modal shows "Hints used: N"
- [x] Win/lose with drawer open — drawer closes automatically before modal appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)