### PR TITLE
Reduce guesses to 6 and fix layout spacing

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,7 +5,7 @@ function App() {
   return (
     <div>
       <div className="header">Pharmdle</div>
-      <Pharmdle numRows={8} />
+      <Pharmdle numRows={6} />
     </div>
   );
 }

--- a/src/Pharmdle.tsx
+++ b/src/Pharmdle.tsx
@@ -22,7 +22,7 @@ const Pharmdle = ({ numRows }: PharmdleGridProps) => {
     setSolution,
     solution,
     message,
-  } = usePharmdle(8, validDrugs);
+  } = usePharmdle(6, validDrugs);
 
   const [modalCleared, setModalCleared] = useState(false);
   const [hints, setHints] = useState<Record<string, string[]> | null>(null);
@@ -56,7 +56,7 @@ const Pharmdle = ({ numRows }: PharmdleGridProps) => {
 
   // Close hints drawer when game ends
   useEffect(() => {
-    if (isCorrect || guesses.length === 8) {
+    if (isCorrect || guesses.length === 6) {
       setDrawerOpen(false);
     }
   }, [isCorrect, guesses.length]);
@@ -66,11 +66,11 @@ const Pharmdle = ({ numRows }: PharmdleGridProps) => {
   }
 
   const shouldShowWonGameModal = () => {
-    return isCorrect && guesses.length <= 8 && !modalCleared;
+    return isCorrect && guesses.length <= 6 && !modalCleared;
   };
 
   const shouldShowLostGameModal = () => {
-    return guesses.length === 8 && !isCorrect;
+    return guesses.length === 6 && !isCorrect;
   };
 
   return (

--- a/src/index.css
+++ b/src/index.css
@@ -15,7 +15,7 @@ body {
   text-transform: uppercase;
   padding: 16px 0;
   border-bottom: 1px solid #3a3a3c;
-  margin: 0 0 24px 0;
+  margin: 0 0 40px 0;
   color: #fff;
 }
 
@@ -76,6 +76,13 @@ body {
 .keypad {
   max-width: 520px;
   margin: 20px auto;
+  position: fixed;
+  bottom: 60px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 100%;
+  padding: 0 8px;
+  box-sizing: border-box;
 }
 .keypad-row {
   display: flex;
@@ -150,7 +157,7 @@ body {
 /* hints button */
 .hints-btn-container {
   text-align: center;
-  margin: 12px 0 20px;
+  margin: 12px 0 200px;
 }
 .hints-btn {
   background: #818384;


### PR DESCRIPTION
## Summary
- Reduce max guesses from 8 to 6
- Fix keypad to bottom of viewport for consistent positioning
- Increase spacing between header and game grid
- Adjust keypad vertical position closer to the grid

## Test plan
- [ ] Game shows 6 rows instead of 8
- [ ] Game ends (lost) after 6 incorrect guesses
- [ ] Win modal still triggers correctly within 6 guesses
- [ ] Keypad stays fixed at bottom of screen
- [ ] Grid is visually centered with good spacing from header and keypad
- [ ] Mobile layout remains responsive

🤖 Generated with [Claude Code](https://claude.com/claude-code)