### PR TITLE
Update README for current game state

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,27 +1,28 @@
 # Pharmdle
 
-A pharmacy-themed word-guessing game inspired by [Wordle](https://www.nytimes.com/games/wordle/index.html). Each day, a new pharmaceutical drug name is selected and players have 8 attempts to guess it using colour-coded feedback.
+A pharmacy-themed word-guessing game inspired by [Wordle](https://www.nytimes.com/games/wordle/index.html). Each day, a new pharmaceutical drug name is selected and players have 6 attempts to guess it using colour-coded feedback.
 
 ## How to Play
 
-1. Each puzzle is a pharmaceutical drug name padded to 14 characters with `*` symbols
-2. Type your guess using the on-screen keyboard or your physical keyboard (letters A-Z and `*`)
-3. Press **Enter** to submit a guess
+1. Each puzzle is a pharmaceutical drug name (up to 14 characters)
+2. Type your guess using the on-screen keyboard or your physical keyboard (letters A-Z)
+3. Press **Enter** to submit a guess — only valid drug names are accepted
 4. After each guess, tiles flip to reveal colour-coded hints:
    - **Green** — correct letter in the correct position
    - **Yellow** — correct letter in the wrong position
    - **Grey** — letter is not in the word
 5. The on-screen keyboard tracks which letters you've used and their best result
-6. Guess the drug name within 8 attempts to win
+6. Use the **Hints** drawer to progressively reveal clues about the drug (route, dosage form, pharmacological class, etc.)
+7. Guess the drug name within 6 attempts to win
 
 ## Architecture
 
 ```
-Frontend (React) --> Lambda Function URL --> getDailyDrug Lambda --> S3 (reads daily_drug)
+Frontend (React) --> Lambda Function URL --> getDailyDrug Lambda --> S3 (reads daily_drug, drug_data)
 
 EventBridge Scheduler (midnight CT) --> rotateDailyDrug Lambda --> S3 (writes daily_drug)
 
-S3 bucket stores: drug_names (full list), daily_drug (today's pick)
+S3 bucket stores: drug_data (full list with hints), daily_drug (today's pick)
 ```
 
 ### Frontend
@@ -36,15 +37,15 @@ S3 bucket stores: drug_names (full list), daily_drug (today's pick)
 
 All backend infrastructure runs in **us-east-1** and is managed via Terraform.
 
-- **S3 bucket** (`842817210846-drug-names`) — stores the list of valid drug names (`drug_names`) and the current daily pick (`daily_drug`)
-- **getDailyDrug Lambda** (Node.js 22.x) — reads `daily_drug` from S3 and returns it as plain text. Exposed via a Lambda Function URL with CORS allowing `GET` from `*`
-- **rotateDailyDrug Lambda** (Node.js 22.x) — reads `drug_names` from S3, picks a random drug, and writes it to `daily_drug` in S3
+- **S3 bucket** (`842817210846-drug-names`) — stores the drug database (`drug_data`) and the current daily pick (`daily_drug`)
+- **getDailyDrug Lambda** (Node.js 22.x) — reads `daily_drug` from S3. Returns JSON with hint attributes when `?hints=true` is passed, otherwise returns the drug name as plain text. Exposed via a Lambda Function URL with CORS allowing `GET` from `*`
+- **rotateDailyDrug Lambda** (Node.js 22.x) — reads `drug_data` from S3, picks a random drug, and writes it to `daily_drug` in S3
 - **EventBridge Scheduler** — triggers `rotateDailyDrug` daily at midnight America/Chicago with a 15-minute flexible window
 - **IAM** — least-privilege roles per Lambda, scoped to the specific S3 keys each function needs
 
 ### Drug List
 
-The drug list is generated from the FDA drug database (`utils/drug-drugsfda-0001-of-0001.json`) using `utils/parse_list.js`, which filters for generic drug names that are alphabetic-only and 14 characters or fewer.
+The drug list is generated from the FDA drug database (`utils/drug-drugsfda-0001-of-0001.json`) using `utils/build_drug_data.py`, which filters for generic drug names that are alphabetic-only and 14 characters or fewer, and enriches each entry with hint attributes (route, dosage form, pharmacological class, etc.).
 
 ## Project Structure
 
@@ -52,13 +53,16 @@ The drug list is generated from the FDA drug database (`utils/drug-drugsfda-0001
 src/
 ├── App.tsx                        # Root component with header
 ├── Pharmdle.tsx                   # Game container and state management
-├── PharmdleRow.tsx                # Single row of 14 letter cells
+├── PharmdleRow.tsx                # Single row of letter cells
 ├── Keypad.tsx                     # On-screen QWERTY keyboard
 ├── hooks/
 │   └── usePharmdle.ts             # Custom hook for core game logic
 ├── components/
+│   ├── HintsDrawer.tsx            # Progressive hint reveal drawer
 │   ├── WonGameModal.tsx           # Victory modal
 │   └── LostGameModal.tsx          # Game-over modal
+├── data/
+│   └── validDrugs.ts              # Static set of valid drug names for guess validation
 └── index.css                      # Global styles and animations
 
 terraform/
@@ -74,8 +78,8 @@ terraform/
     └── rotateDailyDrug/index.mjs  # rotateDailyDrug Lambda source
 
 utils/
-├── parse_list.js                  # Script to extract drug names from FDA data
-├── drug_names                     # Generated list of valid drug names
+├── build_drug_data.py             # Script to build drug database from FDA data
+├── drug_data.json                 # Generated drug database with hint attributes
 └── drug-drugsfda-0001-of-0001.json  # Raw FDA drug database
 ```
 
@@ -129,6 +133,57 @@ aws amplify get-job --app-id d1zf2mt5b84s5d --branch-name main --job-id <JOB_ID>
 ```
 
 You can also check the [Amplify console](https://us-east-1.console.aws.amazon.com/amplify/apps/d1zf2mt5b84s5d) directly.
+
+## Refreshing the Drug Database
+
+To update the game's drug list with new FDA data:
+
+### 1. Obtain new FDA data
+
+Download or place the raw FDA drug database file at `utils/drug-drugsfda-0001-of-0001.json`.
+
+### 2. Generate drug_data.json
+
+```bash
+python3 utils/build_drug_data.py
+```
+
+This reads the raw FDA data, filters to drugs with alphabetic-only names of 14 characters or fewer, enriches each with hint attributes (route, dosage form, pharmacological class, etc.), and writes `utils/drug_data.json`.
+
+### 3. Regenerate the frontend validation list
+
+```bash
+node -e "
+const drugs = require('./utils/drug_data.json');
+const names = drugs.map(d => d.name).sort();
+const ts = 'const validDrugs = new Set<string>([\n' +
+  names.map(n => '  \"' + n + '\"').join(',\n') +
+  ',\n]);\n\nexport default validDrugs;\n';
+require('fs').writeFileSync('src/data/validDrugs.ts', ts);
+console.log('Wrote src/data/validDrugs.ts with ' + names.length + ' drugs');
+"
+```
+
+This generates `src/data/validDrugs.ts`, the static Set used by the frontend to validate guesses.
+
+### 4. Deploy the updated data to S3
+
+```bash
+cd terraform
+terraform apply
+```
+
+Terraform detects changes to `utils/drug_data.json` via its content hash and uploads the new file to S3.
+
+### 5. Trigger a new daily drug (optional)
+
+If you want to immediately pick a new daily drug from the updated list:
+
+```bash
+aws lambda invoke --function-name rotateDailyDrug /dev/stdout
+```
+
+Otherwise, the EventBridge scheduler will pick a new drug at midnight CT automatically.
 
 ## Infrastructure (Terraform)
 


### PR DESCRIPTION
## Summary
- Add step-by-step instructions for refreshing the drug database from new FDA data
- Update outdated sections: 8→6 guesses, remove `*` padding references, document hints drawer feature
- Fix S3/Lambda descriptions to reflect `drug_data` (with hints) instead of `drug_names`
- Update project structure to include HintsDrawer, validDrugs.ts, and build_drug_data.py

## Test plan
- [x] Verify README renders correctly on GitHub
- [x] Follow drug database refresh steps to confirm instructions are accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)