### PR TITLE
Add localStorage game state persistence

### DIFF
--- a/src/Pharmdle.tsx
+++ b/src/Pharmdle.tsx
@@ -1,18 +1,94 @@
 import React, { useEffect, useState } from 'react';
 import PharmdleRow from './PharmdleRow';
 import { Stack } from '@mui/material';
-import usePharmdle from './hooks/usePharmdle';
+import usePharmdle, { InitialGameState } from './hooks/usePharmdle';
 import Keypad from './Keypad';
 import LostGameModal from './components/LostGameModal';
 import WonGameModal from './components/WonGameModal';
 import HintsDrawer from './components/HintsDrawer';
 import validDrugs from './data/validDrugs';
+import { loadGameState, saveGameState, clearGameState } from './utils/gameStorage';
 
 export interface PharmdleGridProps {
   numRows: number;
 }
 
+interface ResolvedState {
+  solution: string;
+  hints: Record<string, string[]>;
+  initialGameState?: InitialGameState;
+  initialRevealedHints: Set<string>;
+}
+
 const Pharmdle = ({ numRows }: PharmdleGridProps) => {
+  const [resolved, setResolved] = useState<ResolvedState | null>(null);
+
+  useEffect(() => {
+    const fetchAndResolve = async () => {
+      const response = await fetch(
+        'https://5bpsqzakript5dai5nolgdvv6e0tkmbr.lambda-url.us-east-1.on.aws/?hints=true'
+      );
+      const data = await response.json();
+      console.log('fetched drug:', data.name);
+      const todaySolution = data.name.toLowerCase();
+      const { name, ...hintData } = data;
+
+      const saved = loadGameState();
+
+      if (saved && saved.solution === todaySolution) {
+        setResolved({
+          solution: todaySolution,
+          hints: hintData,
+          initialGameState: {
+            guesses: saved.guesses,
+            isCorrect: saved.isCorrect,
+            usedKeys: saved.usedKeys,
+          },
+          initialRevealedHints: new Set(saved.revealedHints),
+        });
+      } else {
+        clearGameState();
+        setResolved({
+          solution: todaySolution,
+          hints: hintData,
+          initialRevealedHints: new Set(),
+        });
+      }
+    };
+
+    fetchAndResolve();
+  }, []);
+
+  if (!resolved) {
+    return <div>Loading...</div>;
+  }
+
+  return (
+    <PharmdleGame
+      numRows={numRows}
+      solution={resolved.solution}
+      hints={resolved.hints}
+      initialGameState={resolved.initialGameState}
+      initialRevealedHints={resolved.initialRevealedHints}
+    />
+  );
+};
+
+interface PharmdleGameProps {
+  numRows: number;
+  solution: string;
+  hints: Record<string, string[]>;
+  initialGameState?: InitialGameState;
+  initialRevealedHints: Set<string>;
+}
+
+const PharmdleGame = ({
+  numRows,
+  solution: initialSolution,
+  hints,
+  initialGameState,
+  initialRevealedHints,
+}: PharmdleGameProps) => {
   const {
     currentGuess,
     guesses,
@@ -22,37 +98,23 @@ const Pharmdle = ({ numRows }: PharmdleGridProps) => {
     setSolution,
     solution,
     message,
-  } = usePharmdle(6, validDrugs);
+  } = usePharmdle(6, validDrugs, initialGameState);
 
   const [modalCleared, setModalCleared] = useState(false);
-  const [hints, setHints] = useState<Record<string, string[]> | null>(null);
   const [drawerOpen, setDrawerOpen] = useState(false);
-  const [hintsUsed, setHintsUsed] = useState(0);
+  const [revealedHints, setRevealedHints] = useState<Set<string>>(initialRevealedHints);
+
+  const hintsUsed = revealedHints.size;
 
   useEffect(() => {
-    const fetchDailyDrug = async () => {
-      const response = await fetch(
-        'https://5bpsqzakript5dai5nolgdvv6e0tkmbr.lambda-url.us-east-1.on.aws/?hints=true'
-      );
-      const data = await response.json();
-      console.log('fetched drug:', data.name);
-      setSolution(data.name.toLowerCase());
-      const { name, ...hintData } = data;
-      setHints(hintData);
-    };
-
-    fetchDailyDrug();
-  }, []);
+    setSolution(initialSolution);
+  }, [initialSolution, setSolution]);
 
   useEffect(() => {
     window.addEventListener('keyup', handleKeyup);
 
     return () => window.removeEventListener('keyup', handleKeyup);
   }, [handleKeyup]);
-
-  // console.log(
-  //   `turn: ${guesses.length}, currentGuess: ${currentGuess}, guesses: ${guesses}, usedKeys: ${usedKeys}, isCorrect: ${isCorrect}`
-  // );
 
   // Close hints drawer when game ends
   useEffect(() => {
@@ -61,9 +123,25 @@ const Pharmdle = ({ numRows }: PharmdleGridProps) => {
     }
   }, [isCorrect, guesses.length]);
 
-  if (!solution) {
-    return <div>Loading...</div>;
-  }
+  // Persist game state to localStorage
+  useEffect(() => {
+    if (!solution) return;
+    saveGameState({
+      solution,
+      guesses,
+      isCorrect,
+      usedKeys,
+      revealedHints: Array.from(revealedHints),
+    });
+  }, [solution, guesses, isCorrect, usedKeys, revealedHints]);
+
+  const handleHintReveal = (hintKey: string) => {
+    setRevealedHints((prev) => {
+      const updated = new Set(prev);
+      updated.add(hintKey);
+      return updated;
+    });
+  };
 
   const shouldShowWonGameModal = () => {
     return isCorrect && guesses.length <= 6 && !modalCleared;
@@ -91,7 +169,8 @@ const Pharmdle = ({ numRows }: PharmdleGridProps) => {
         hints={hints}
         open={drawerOpen}
         onToggle={() => setDrawerOpen(!drawerOpen)}
-        onReveal={(count) => setHintsUsed(count)}
+        revealedHints={revealedHints}
+        onReveal={handleHintReveal}
       />
       <LostGameModal
         open={shouldShowLostGameModal() && !modalCleared}

--- a/src/components/HintsDrawer.tsx
+++ b/src/components/HintsDrawer.tsx
@@ -1,10 +1,11 @@
-import React, { useState, useMemo } from 'react';
+import React, { useMemo } from 'react';
 
 interface HintsDrawerProps {
   hints: Record<string, string[]> | null;
   open: boolean;
   onToggle: () => void;
-  onReveal: (count: number) => void;
+  revealedHints: Set<string>;
+  onReveal: (hintKey: string) => void;
 }
 
 const HINT_LABELS: Record<string, string> = {
@@ -25,22 +26,13 @@ const HINT_ORDER = [
   'pharm_class_moa',
 ];
 
-const HintsDrawer = ({ hints, open, onToggle, onReveal }: HintsDrawerProps) => {
-  const [revealedHints, setRevealedHints] = useState<Set<string>>(new Set());
-
+const HintsDrawer = ({ hints, open, onToggle, revealedHints, onReveal }: HintsDrawerProps) => {
   const availableHints = useMemo(() => {
     if (!hints) return [];
     return HINT_ORDER.filter((key) => hints[key]?.length > 0);
   }, [hints]);
 
   if (!hints) return null;
-
-  const handleReveal = (key: string) => {
-    const updated = new Set(revealedHints);
-    updated.add(key);
-    setRevealedHints(updated);
-    onReveal(updated.size);
-  };
 
   const revealedCount = revealedHints.size;
   const totalCount = availableHints.length;
@@ -71,7 +63,7 @@ const HintsDrawer = ({ hints, open, onToggle, onReveal }: HintsDrawerProps) => {
               ) : (
                 <button
                   className="hint-reveal-btn"
-                  onClick={() => handleReveal(key)}
+                  onClick={() => onReveal(key)}
                 >
                   Reveal
                 </button>

--- a/src/hooks/usePharmdle.ts
+++ b/src/hooks/usePharmdle.ts
@@ -98,11 +98,17 @@ export interface KeyColorMap {
   z?: Color;
 }
 
-const usePharmdle = (numTurns: number, validDrugs: Set<string>) => {
+export interface InitialGameState {
+  guesses: Guess[];
+  isCorrect: boolean;
+  usedKeys: KeyColorMap;
+}
+
+const usePharmdle = (numTurns: number, validDrugs: Set<string>, initialState?: InitialGameState) => {
   const [currentGuess, setCurrentGuess] = useState('');
-  const [guesses, setGuesses] = useState<Guess[]>([]);
-  const [isCorrect, setIsCorrect] = useState(false);
-  const [usedKeys, setUsedKeys] = useState<KeyColorMap>({});
+  const [guesses, setGuesses] = useState<Guess[]>(initialState?.guesses ?? []);
+  const [isCorrect, setIsCorrect] = useState(initialState?.isCorrect ?? false);
+  const [usedKeys, setUsedKeys] = useState<KeyColorMap>(initialState?.usedKeys ?? {});
   const [solution, setSolution] = useState<string>('');
   const [message, setMessage] = useState<string>('');
 

--- a/src/utils/gameStorage.ts
+++ b/src/utils/gameStorage.ts
@@ -1,0 +1,33 @@
+import { Guess, KeyColorMap } from '../hooks/usePharmdle';
+
+const STORAGE_KEY = 'pharmdle-state';
+
+export interface PersistedGameState {
+  solution: string;
+  guesses: Guess[];
+  isCorrect: boolean;
+  usedKeys: KeyColorMap;
+  revealedHints: string[];
+}
+
+export function loadGameState(): PersistedGameState | null {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return null;
+    return JSON.parse(raw) as PersistedGameState;
+  } catch {
+    return null;
+  }
+}
+
+export function saveGameState(state: PersistedGameState): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+  } catch {
+    // localStorage full or unavailable; silently fail
+  }
+}
+
+export function clearGameState(): void {
+  localStorage.removeItem(STORAGE_KEY);
+}


### PR DESCRIPTION
## Summary
- Persist game progress (guesses, keyboard state, revealed hints) to `localStorage` so users can resume after refreshing
- Detect new daily puzzles by comparing stored solution against the API response; automatically clear stale state
- Split `Pharmdle` into an outer fetch/resolve shell and inner `PharmdleGame` component to ensure correct initial state on first render
- Lift `revealedHints` from `HintsDrawer` internal state to parent for persistence; derive `hintsUsed` from `revealedHints.size`

## Test plan
- [x] Play a game, make a few guesses and reveal a hint, then refresh — state should be restored
- [x] Win or lose, then refresh — result modal reappears with correct data
- [x] Simulate a new day (edit `pharmdle-state` in localStorage to change the solution) — game resets to fresh state
- [ ] Open in private/incognito mode — game works normally without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)