### PR TITLE
Add info modal with game instructions

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,11 +1,20 @@
-import React from 'react';
+import React, { useState } from 'react';
 import Pharmdle from './Pharmdle';
+import InfoModal from './components/InfoModal';
 
 function App() {
+  const [infoOpen, setInfoOpen] = useState(false);
+
   return (
     <div>
-      <div className="header">Pharmdle</div>
+      <div className="header">
+        <span>Pharmdle</span>
+        <button className="header-info-btn" onClick={() => setInfoOpen(true)}>
+          ?
+        </button>
+      </div>
       <Pharmdle numRows={6} />
+      <InfoModal open={infoOpen} onClose={() => setInfoOpen(false)} />
     </div>
   );
 }

--- a/src/components/InfoModal.tsx
+++ b/src/components/InfoModal.tsx
@@ -1,0 +1,86 @@
+import { Button } from '@mui/material';
+import React from 'react';
+
+const InfoModal = ({
+  open,
+  onClose,
+}: {
+  open: boolean;
+  onClose: () => void;
+}) => {
+  return (
+    <div className="modal" hidden={!open}>
+      <div className="modal-content info-modal-content">
+        <h2>How to Play</h2>
+
+        <div className="info-section">
+          <p>
+            Pharmdle is a pharmacy-themed word-guessing game. Each day, a new
+            pharmaceutical drug name is selected and you have 6 attempts to guess
+            it.
+          </p>
+        </div>
+
+        <div className="info-section">
+          <h3>Rules</h3>
+          <ol>
+            <li>Type a valid drug name using the on-screen or physical keyboard</li>
+            <li>Press <strong>Enter</strong> to submit your guess</li>
+            <li>After each guess, tiles flip to reveal colour-coded feedback</li>
+            <li>Use the feedback to narrow down the answer</li>
+            <li>The drug name may be shorter than 14 characters — empty tiles past the answer will turn green</li>
+          </ol>
+        </div>
+
+        <div className="info-section">
+          <h3>Colour Guide</h3>
+          <div className="color-legend">
+            <div className="color-legend-row">
+              <span className="color-example green">A</span>
+              <span>Correct letter in the correct position</span>
+            </div>
+            <div className="color-legend-row">
+              <span className="color-example yellow">A</span>
+              <span>Correct letter in the wrong position</span>
+            </div>
+            <div className="color-legend-row">
+              <span className="color-example grey">A</span>
+              <span>Letter is not in the word</span>
+            </div>
+          </div>
+        </div>
+
+        <div className="info-section">
+          <h3>Hints</h3>
+          <p>
+            Tap the <strong>Hints</strong> button to open the hints drawer. You
+            can progressively reveal clues about the drug, such as its route,
+            dosage form, and pharmacological class. The number of hints you use
+            is tracked and shown at the end of the game.
+          </p>
+        </div>
+
+        <div className="info-section">
+          <h3>About</h3>
+          <p>
+            Drug data sourced from the{' '}
+            <a
+              href="https://open.fda.gov/"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              FDA openFDA database
+            </a>
+            . A new puzzle is available every day at midnight CT.
+          </p>
+        </div>
+
+        <Button variant="outlined" onClick={onClose}>
+          Close
+        </Button>
+      </div>
+    </div>
+  );
+};
+
+export default InfoModal;

--- a/src/index.css
+++ b/src/index.css
@@ -9,6 +9,10 @@ body {
 
 /* header */
 .header {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  position: relative;
   font-size: 1.4em;
   font-weight: bold;
   letter-spacing: 0.1em;
@@ -17,6 +21,25 @@ body {
   border-bottom: 1px solid #3a3a3c;
   margin: 0 0 40px 0;
   color: #fff;
+}
+.header-info-btn {
+  position: absolute;
+  right: 16px;
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  border: 1px solid #3a3a3c;
+  background: transparent;
+  color: #818384;
+  font-size: 0.7em;
+  font-weight: bold;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.header-info-btn:active {
+  transform: scale(0.95);
 }
 
 /* rows */
@@ -137,7 +160,7 @@ body {
   top: 0;
   left: 0;
 }
-.modal div {
+.modal-content {
   max-width: 480px;
   background: #1a1a1b;
   color: #fff;
@@ -152,6 +175,74 @@ body {
   font-size: 0.8em;
   text-transform: uppercase;
   letter-spacing: 1px;
+}
+
+/* info modal */
+.info-modal-content {
+  max-height: 70vh;
+  overflow-y: auto;
+  text-align: left;
+}
+.info-modal-content h2 {
+  text-align: center;
+  margin-top: 0;
+}
+.info-modal-content h3 {
+  font-size: 0.9em;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: #818384;
+  margin-bottom: 8px;
+}
+.info-modal-content p {
+  font-size: 0.9em;
+  line-height: 1.5;
+}
+.info-modal-content ol {
+  padding-left: 20px;
+  font-size: 0.9em;
+  line-height: 1.8;
+}
+.info-modal-content a {
+  color: #538d4e;
+}
+.info-section {
+  margin-bottom: 20px;
+}
+.info-section:last-of-type {
+  margin-bottom: 24px;
+}
+.color-legend {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.color-legend-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  font-size: 0.9em;
+}
+.color-example {
+  width: 36px;
+  height: 36px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: bold;
+  font-size: 1.2em;
+  text-transform: uppercase;
+  border-radius: 4px;
+  flex-shrink: 0;
+}
+.color-example.green {
+  background: #538d4e;
+}
+.color-example.yellow {
+  background: #b59f3b;
+}
+.color-example.grey {
+  background: #3a3a3c;
 }
 
 /* hints button */


### PR DESCRIPTION
## Summary
- Add a "?" button in the header that opens an info modal
- Modal includes: game description, rules (including variable-length drug names), colour guide with tile examples, hints explanation, and credits with FDA link
- Fix `.modal div` CSS selector to `.modal-content` to prevent styling nested divs in the info modal
- Header updated to flexbox layout with relatively positioned info button

## Test plan
- [x] "?" button visible in top-right of header
- [x] Clicking "?" opens modal with all info sections
- [x] Colour guide shows green/yellow/grey tile examples
- [x] "Close" button dismisses the modal
- [x] Win/lose modals still render correctly (no regression from CSS selector fix)
- [x] Modal scrollable on small viewports

🤖 Generated with [Claude Code](https://claude.com/claude-code)