### PR TITLE
Add submit feedback button

### DIFF
--- a/src/components/InfoModal.tsx
+++ b/src/components/InfoModal.tsx
@@ -75,9 +75,19 @@ const InfoModal = ({
           </p>
         </div>
 
-        <Button variant="outlined" onClick={onClose}>
-          Close
-        </Button>
+        <div className="info-modal-buttons">
+          <Button
+            variant="outlined"
+            href="https://docs.google.com/forms/d/e/1FAIpQLSfmctEN7bDDdJC95Wxrr_T_usrRplLmCvl7WgmnfEs63QvA_Q/viewform"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Submit Feedback
+          </Button>
+          <Button variant="outlined" onClick={onClose}>
+            Close
+          </Button>
+        </div>
       </div>
     </div>
   );

--- a/src/index.css
+++ b/src/index.css
@@ -212,6 +212,11 @@ body {
 .info-section:last-of-type {
   margin-bottom: 24px;
 }
+.info-modal-buttons {
+  display: flex;
+  gap: 12px;
+  justify-content: center;
+}
 .color-legend {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
- Add a "Submit Feedback" button in the info modal that opens an external Google Form in a new tab
- Buttons displayed side by side (Submit Feedback + Close)

## Test plan
- [x] Open info modal via "?" header button
- [x] "Submit Feedback" button visible next to "Close"
- [x] Clicking "Submit Feedback" opens the Google Form in a new tab
- [x] "Close" button still dismisses the modal

🤖 Generated with [Claude Code](https://claude.com/claude-code)